### PR TITLE
Fix for #28 - Changed sflems/django-constance to non-editable install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ certifi==2020.12.5
 colorzero==1.1
 Django==3.1.3
 django-bootstrap4==2.3.1
--e git+https://github.com/sflems/django-constance.git@master#egg=django-constance
+django-constance @ git+https://github.com/sflems/django-constance.git@master#egg=django-constance
 django-cors-headers==3.7.0
 django-crispy-forms==1.10.0
 django-jsonforms==1.1.2


### PR DESCRIPTION
Fix for issue #28.

Pip was attempting to install [`sflems/django-constance`](https://github.com/sflems/django-constance) as an editable package. This has been changed for LED Scoreboard usage. See [PIP install docs](https://pip.pypa.io/en/stable/cli/pip_install/#pip-install-examples) for reference.

Key error info:

```
WARNING: Discarding git+https://github.com/sflems/django-constance.git@master#egg=django-constance. Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.

...

ERROR: Could not find a version that satisfies the requirement django-constance (unavailable)
ERROR: No matching distribution found for django-constance (unavailable)
```